### PR TITLE
byte can't concatenate to string

### DIFF
--- a/joomblah.py
+++ b/joomblah.py
@@ -42,7 +42,7 @@ def joomla_370_sqli_extract(options, sess, token, colname, morequery):
 		if not value:
 			print(" [!] Failed to retrieve string for query:", sqli)
 			return None
-		value = binascii.unhexlify(value)
+		value = binascii.unhexlify(value).decode()
 		result += value
 		offset += len(value)
 	return result


### PR DESCRIPTION
In the line 46 it is try to concatenate but it is not possible it will throw error  **byte can't concatenate to string**   So firstly we have to decode the byte to the string the line 45 then t will work fine